### PR TITLE
Install and export the target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,39 +5,82 @@ add_definitions(-W -Wall -Wextra)
 
 ## Enforce that we use C++17
 set(CMAKE_CXX_STANDARD 17)
-
-
-find_package(catkin)
-if(${catkin_FOUND})
-  include_directories(${catkin_INCLUDE_DIRS})
-  link_directories(${catkin_LIBRARY_DIRS})
-
-
-  catkin_package(
-    INCLUDE_DIRS include
-    LIBRARIES ${PROJECT_NAME}
-  )
-endif()
+set(CONFIG_NAMESPACE_CMAKE "betwo")
+set(PACKAGE_VERSION 0.0.0)  # Use git tags ??
 
 enable_testing()
 
-add_library(lightfsm
-  src/action.cpp
-  src/actions.cpp
-  src/event.cpp
-  src/guard.cpp
-  src/meta_state.cpp
-  src/state_machine_basic_executor.cpp
-  src/state_machine_executor.cpp
-  src/state_machine.cpp
-  src/state.cpp
-  src/transition.cpp
-  src/triggered_event.cpp
+add_library(${PROJECT_NAME}
+  SHARED
+    src/action.cpp
+    src/actions.cpp
+    src/event.cpp
+    src/guard.cpp
+    src/meta_state.cpp
+    src/state_machine_basic_executor.cpp
+    src/state_machine_executor.cpp
+    src/state_machine.cpp
+    src/state.cpp
+    src/transition.cpp
+    src/triggered_event.cpp
 )
-target_include_directories(lightfsm
+target_include_directories(${PROJECT_NAME}
   PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/include
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
 add_subdirectory(examples)
 add_subdirectory(tests)
+
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+include(CMakePackageConfigHelpers)
+include(GenerateExportHeader)
+generate_export_header(lightfsm)
+
+write_basic_package_version_file(
+  lightfsmVersion.cmake
+  VERSION ${PACKAGE_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
+set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
+
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/lightfsm-config-version.cmake"
+  VERSION ${PACKAGE_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(
+  ${PROJECT_NAME}-config.cmake.in
+  ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION ${ConfigPackageLocation}
+)
+
+install(EXPORT ${PROJECT_NAME}-targets
+  FILE ${PROJECT_NAME}-targets.cmake
+  NAMESPACE ${CONFIG_NAMESPACE_CMAKE}::
+  DESTINATION ${ConfigPackageLocation}
+)
+
+install(
+  FILES
+    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}-config-version.cmake"
+  DESTINATION ${ConfigPackageLocation}
+  COMPONENT Development
+)

--- a/cmake/read_version.cmake
+++ b/cmake/read_version.cmake
@@ -1,0 +1,12 @@
+# Reads the content of the `version` tag in the package.xml file
+function (read_version OUT_VERSION)
+    # read the package.xml file
+    file(READ ${CMAKE_CURRENT_LIST_DIR}/package.xml PACKAGE_XML_CONTENTS)
+
+    # find the version tag
+    string(REGEX MATCH "^.*<version>([^<]*)</version>.*$" match ${PACKAGE_XML_CONTENTS})
+    if(match)
+        # return the text of the version tag
+        set(${OUT_VERSION} ${CMAKE_MATCH_1} PARENT_SCOPE)
+    endif()
+endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,7 +4,11 @@ function(add_lightfsm_example_example NAME)
     )
     target_link_libraries(${PROJECT_NAME}_example_${NAME}
         ${PROJECT_NAME}
-        ${catkin_LIBRARIES}
+    )
+
+    install(TARGETS
+        ${PROJECT_NAME}_example_${NAME}
+        DESTINATION lib/${PROJECT_NAME}
     )
 endfunction()
 

--- a/lightfsm-config.cmake.in
+++ b/lightfsm-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+# -- Edit here if you need any transitive packages (PUBLIC) existing
+# find_package(Threads REQUIRED)
+
+if (NOT TARGET "@CONFIG_NAMESPACE_CMAKE@::@PROJECT_NAME@")
+  include ( "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake" )
+endif()

--- a/package.xml
+++ b/package.xml
@@ -8,8 +8,9 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>cmake</buildtool_depend>
 
   <export>
+    <build_type>cmake</build_type>
   </export>
 </package>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,31 +1,16 @@
-
-find_package(catkin)
-
 file(GLOB_RECURSE TEST_SOURCES "*.cpp")
 
-if (${catkin_FOUND})
-    catkin_add_gtest(${PROJECT_NAME}_tests
-        ${TEST_SOURCES}
-    )
-    target_link_libraries(${PROJECT_NAME}_tests
-        ${PROJECT_NAME}
-        ${catkin_LIBRARIES}
-        gtest_main
-    )
+find_package(GTest REQUIRED)
+include(GoogleTest)
 
-else()
-    find_package(GTest REQUIRED)
-    include(GoogleTest)
+ add_executable(${PROJECT_NAME}_tests
+   ${TEST_SOURCES}
+ )
+ target_link_libraries(
+   ${PROJECT_NAME}_tests
+   ${PROJECT_NAME}
+   GTest::GTest
+   gtest_main
+ )
 
-    add_executable(${PROJECT_NAME}_tests
-      ${TEST_SOURCES}
-    )
-    target_link_libraries(
-      ${PROJECT_NAME}_tests
-      ${PROJECT_NAME}
-      GTest::GTest
-      gtest_main
-    )
-
-    gtest_discover_tests(${PROJECT_NAME}_tests)
-endif()
+gtest_discover_tests(${PROJECT_NAME}_tests)


### PR DESCRIPTION
The CMakeLists.txt where a bit update, such that
the project is no build as plain modern cmake project. Currently, it can be build with in a ROS 1 and ROS 2 workspace via catkin build, or respectively, colcon build.

If you would like to use the lib in a ROS 1 or ROS 2 package, simply call `find_package(lightfsm)` and use
`target_link_library(<your exe. or lib.> betwo::lightfsm)`.